### PR TITLE
Disable C sanitization

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -89,6 +89,7 @@ pub fn build(builder: *std.Build) !void {
             .root_source_file = builder.addWriteFiles().add("empty.zig", ""),
             .target = target,
             .optimize = optimize,
+            .sanitize_c = .off,
         }),
     });
 


### PR DESCRIPTION
Fixes linking issues in optimized builds (at least on windows). 
Basically same as: https://github.com/zig-gamedev/zglfw/issues/35