### PR TITLE
Updates for Zig 0.16.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,26 +7,28 @@ fn update(toolbox: *Toolbox) !void {
         "glfw",
     });
 
-    std.fs.deleteTreeAbsolute(glfw_path) catch |err| {
-        switch (err) {
-            error.FileNotFound => {},
-            else => return err,
-        }
-    };
+    std.debug.assert(std.fs.path.isAbsolute(glfw_path));
+    try std.Io.Dir.deleteTree(.cwd(), toolbox.getIo(), glfw_path);
 
     try toolbox.clone(.glfw, glfw_path);
 
-    var glfw_dir = try std.fs.openDirAbsolute(glfw_path, .{
+    var glfw_dir = try std.Io.Dir.openDirAbsolute(toolbox.getIo(), glfw_path, .{
         .iterate = true,
     });
-    defer glfw_dir.close();
+    defer glfw_dir.close(toolbox.getIo());
 
     var it = glfw_dir.iterate();
-    while (try it.next()) |*entry| {
+    while (try it.next(toolbox.getIo())) |*entry| {
         if (!std.mem.eql(u8, entry.name, "src") and !std.mem.eql(u8, entry.name, "include")) {
-            try std.fs.deleteTreeAbsolute(toolbox.pathJoin(&.{
-                glfw_path, entry.name,
-            }));
+            std.debug.assert(std.fs.path.isAbsolute(toolbox.pathJoin(&.{
+                glfw_path,
+                entry.name,
+            })));
+            try std.Io.Dir.deleteTree(
+                .cwd(),
+                toolbox.getIo(),
+                toolbox.pathJoin(&.{ glfw_path, entry.name }),
+            );
         }
     }
 
@@ -90,18 +92,17 @@ pub fn build(builder: *std.Build) !void {
             .target = target,
             .optimize = optimize,
             .sanitize_c = .off,
+            .link_libc = true,
         }),
     });
 
-    lib.linkLibC();
-
-    var root_dir = try builder.build_root.handle.openDir(".", .{
+    var root_dir = try builder.build_root.handle.openDir(toolbox.getIo(), ".", .{
         .iterate = true,
     });
-    defer root_dir.close();
+    defer root_dir.close(toolbox.getIo());
 
     var walk = try root_dir.walk(builder.allocator);
-    while (try walk.next()) |*entry| {
+    while (try walk.next(toolbox.getIo())) |*entry| {
         if (std.mem.startsWith(u8, entry.path, "glfw") and entry.kind == .directory) {
             toolbox.addInclude(lib, entry.path);
         }
@@ -124,23 +125,23 @@ pub fn build(builder: *std.Build) !void {
         "glfw", "src",
     });
 
-    var src_dir = try std.fs.openDirAbsolute(src_path, .{
+    var src_dir = try std.Io.Dir.openDirAbsolute(toolbox.getIo(), src_path, .{
         .iterate = true,
     });
-    defer src_dir.close();
+    defer src_dir.close(toolbox.getIo());
 
     switch (target.result.os.tag) {
         .windows => {
-            lib.linkSystemLibrary("gdi32");
-            lib.linkSystemLibrary("user32");
-            lib.linkSystemLibrary("shell32");
+            lib.root_module.linkSystemLibrary("gdi32", .{});
+            lib.root_module.linkSystemLibrary("user32", .{});
+            lib.root_module.linkSystemLibrary("shell32", .{});
 
             const flags = [_][]const u8{
                 "-D_GLFW_WIN32", "-Isrc",
             };
 
             var it = src_dir.iterate();
-            while (try it.next()) |*entry| {
+            while (try it.next(toolbox.getIo())) |*entry| {
                 if ((!std.mem.startsWith(u8, entry.name, "linux_") and
                     !std.mem.startsWith(u8, entry.name, "posix_") and
                     !std.mem.startsWith(u8, entry.name, "xkb_") and
@@ -156,9 +157,9 @@ pub fn build(builder: *std.Build) !void {
             }
         },
         .macos => {
-            lib.linkFramework("Cocoa");
-            lib.linkFramework("CoreFoundation");
-            lib.linkFramework("IOKit");
+            lib.root_module.linkFramework("Cocoa", .{});
+            lib.root_module.linkFramework("CoreFoundation", .{});
+            lib.root_module.linkFramework("IOKit", .{});
 
             const flags = [_][]const u8{
                 "-D_GLFW_COCOA",
@@ -166,7 +167,7 @@ pub fn build(builder: *std.Build) !void {
             };
 
             var it = src_dir.iterate();
-            while (try it.next()) |*entry| {
+            while (try it.next(toolbox.getIo())) |*entry| {
                 if ((!std.mem.startsWith(u8, entry.name, "linux_") and
                     !std.mem.startsWith(u8, entry.name, "xkb_") and
                     !std.mem.startsWith(u8, entry.name, "glx_") and
@@ -186,15 +187,15 @@ pub fn build(builder: *std.Build) !void {
                 .optimize = optimize,
             });
 
-            for (X11_dep.artifact("X11").root_module.include_dirs.items) |*included| lib.addIncludePath(included.path);
+            for (X11_dep.artifact("X11").root_module.include_dirs.items) |*included| lib.root_module.addIncludePath(included.path);
 
             const wayland_dep = builder.dependency("wayland_zig", .{
                 .target = target,
                 .optimize = optimize,
             });
 
-            lib.linkLibrary(X11_dep.artifact("X11"));
-            lib.linkLibrary(wayland_dep.artifact("wayland"));
+            lib.root_module.linkLibrary(X11_dep.artifact("X11"));
+            lib.root_module.linkLibrary(wayland_dep.artifact("wayland"));
             lib.installLibraryHeaders(X11_dep.artifact("X11"));
             lib.installLibraryHeaders(wayland_dep.artifact("wayland"));
 
@@ -203,7 +204,7 @@ pub fn build(builder: *std.Build) !void {
             };
 
             var it = src_dir.iterate();
-            while (try it.next()) |*entry| {
+            while (try it.next(toolbox.getIo())) |*entry| {
                 if ((!std.mem.startsWith(u8, entry.name, "wgl_") and
                     !std.mem.startsWith(u8, entry.name, "win32_") and
                     !std.mem.startsWith(u8, entry.name, "cocoa_") and

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,25 +1,25 @@
 .{
     .name = .glfw_zig,
-    .version = "1.0.0",
+    .version = "1.0.1",
     .dependencies = .{
         .toolbox = .{
-            .url = "git+https://github.com/tiawl/toolbox?ref=1.12.6#79c1dffe608a9c4a7dcf11f98f1dc88b9b46e9f5",
-            .hash = "toolbox-1.12.6-kRAu4BJbAAAGPWPltdn1vwY83xau2Zh9015JTQ0MZjyM",
+            .url = "git+https://github.com/apm5127/toolbox.git?ref=update-zig#53d8342f24a9213fa6454ab6f15605c6ac35c8ab",
+            .hash = "toolbox-1.12.7-kRAu4DRlAAC0RRGTn0MRUxiv6TKMUAvWqnnXKs2UF3F7",
         },
         .wayland_zig = .{
-            .url = "git+https://github.com/tiawl/wayland.zig?ref=wayland-protocols-1.47#3d9fd2ccfac8b61344b7becba3a54acb25f26ed5",
-            .hash = "wayland_zig-1.0.0-JmY-j0k_CgBILUhhfEM-RdwZjP8pFOiQvpmoGMm_-uHO",
+            .url = "git+https://github.com/apm5127/wayland.zig.git?ref=update-zig#c8f747fb853db5c41057d6dce67b6fa1c36a6d9a",
+            .hash = "wayland_zig-1.0.1-JmY-j9dACgDHfjaNxoomouAt09rv7p1-2k5gZ-i5ulTG",
         },
         .X11_zig = .{
-            .url = "git+https://github.com/tiawl/X11.zig?ref=libXext-1.3.7#a7ae948e364a3105ea3157128239c8c818c68352",
-            .hash = "X11_zig-1.0.0-UuAzbMxlwADqtBm9hneM2bqQO_Tj0yovhrifMM8OCWOd",
+            .url = "git+https://github.com/apm5127/x11.zig.git?ref=update-zig#1e0bd4bae2c7c87d68d6f21ce37060c10b2e7064",
+            .hash = "X11_zig-1.0.1-UuAzbDFuwAAZNzJ8Ir1BqCFohjJgWmf5h8IUagPvtl-k",
         },
         .vulkan_zig = .{
-            .url = "git+https://github.com/tiawl/vulkan.zig?ref=v1.4.342#f494a3d82b7df46e29b2b72e1522b09ad488fa7a",
-            .hash = "vulkan_zig-1.0.0-p2wg3mmyPQHiAxPvc4TQaiC70ZYYYGY1uQqfIdWutmdz",
+            .url = "git+https://github.com/apm5127/vulkan.zig.git?ref=update-zig#ad62a4ff80a72b521a2539b8416d5c76a6ac078f",
+            .hash = "vulkan_zig-1.0.1-p2wg3v-yPQE7XYDBvmsbVfm3XzUPAa4Id9ldL8O2AJmd",
         },
     },
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
     .fingerprint = 0xcba456a5a3d8bb36,
     .paths = .{
         "build.zig",


### PR DESCRIPTION
I've updated the build.zig in my forks of [glfw.zig](https://github.com/apm5127/glfw.zig/tree/update-zig), [wayland.zig](https://github.com/apm5127/wayland.zig/tree/update-zig), [vulkan.zig](https://github.com/apm5127/vulkan.zig/tree/update-zig), [x11.zig](https://github.com/apm5127/x11.zig/tree/update-zig), and [toolbox](https://github.com/apm5127/toolbox/tree/update-zig) to compile using the latest Zig `master` branch, version `0.16.0-dev.2510+bcb5218a2`.

Since Zig 0.16.0 is not released yet, I think the updates could go into a branch tracking Zig `master` until 0.16.0 releases. Could you please add a branch called `zig-master` or something for merging Zig 0.16.0 updates until then?

I had to change the dependencies in the build.zig.zon files to my forks, so they will require updating after merging the build.zig files.

PS: this is my first pull request, so please bear with me as I try to figure the system out.